### PR TITLE
feat: 買い物記録編集機能を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5919,9 +5919,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001692",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
       "dev": true,
       "funding": [
         {
@@ -5936,7 +5936,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "5.2.0",

--- a/src/entities/shopping/ui/ShoppingAmountItem.vue
+++ b/src/entities/shopping/ui/ShoppingAmountItem.vue
@@ -12,7 +12,7 @@
 
   const handleReceiptAnalyzeResult = {
     openModal: () => {
-      if (props.shoppingRecord.analyze_id === 0) {
+      if ((props.shoppingRecord.analyze_id || 0) === 0) {
         return
       }
       isOpenReceiptAnalyzeResultModal.value = true
@@ -24,6 +24,7 @@
 
   defineEmits<{
     click: [id: number]
+    edit: [record: components['schemas']['ShoppingRecord']]
   }>()
 </script>
 <template>
@@ -35,15 +36,15 @@
       @click="handleReceiptAnalyzeResult.openModal"
     >
       <div class="flex items-center flex-1 min-w-0">
-        <ShoppingCategoryIcon :categoryName="shoppingRecord.category.name" />
+        <ShoppingCategoryIcon :categoryName="shoppingRecord.category?.name || ''" />
         <div class="min-w-0">
           <div class="flex gap-2 flex-nowrap items-center min-w-0">
             <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
-              {{ formatDateFromDate(new Date(shoppingRecord.date)) }}
+              {{ formatDateFromDate(new Date(shoppingRecord.date || '')) }}
             </p>
 
             <span
-              v-if="shoppingRecord.analyze_id !== 0"
+              v-if="(shoppingRecord.analyze_id || 0) !== 0"
               class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 whitespace-nowrap min-w-[48px] justify-center"
             >
               AI解析
@@ -51,31 +52,49 @@
           </div>
 
           <p class="font-medium text-gray-700 dark:text-gray-200">
-            {{ shoppingRecord.category.name }}
+            {{ shoppingRecord.category?.name || '' }}
           </p>
           <p class="text-sm text-gray-600 dark:text-gray-300 truncate">
             {{
-              shoppingRecord.memo.length > 10
-                ? shoppingRecord.memo.slice(0, 10) + '...'
-                : shoppingRecord.memo
+              (shoppingRecord.memo || '').length > 10
+                ? (shoppingRecord.memo || '').slice(0, 10) + '...'
+                : (shoppingRecord.memo || '')
             }}
           </p>
         </div>
       </div>
       <div class="text-right min-w-[80px] flex-shrink-0">
         <p class="text-xl font-bold text-indigo-600 dark:text-indigo-400">
-          ¥{{ shoppingRecord.amount.toLocaleString() }}
+          ¥{{ (shoppingRecord.amount || 0).toLocaleString() }}
         </p>
       </div>
-      <div class="ml-1 flex-shrink-0">
+      <div class="ml-1 flex-shrink-0 flex gap-1">
         <button
-          @click="$emit('click', shoppingRecord.id)"
-          class="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-500 duration-300 bg-red-100 hover:bg-red-200 shadow-md hover:shadow-lg"
+          @click.stop="$emit('edit', shoppingRecord)"
+          class="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-500 duration-300 bg-blue-100 hover:bg-blue-200 p-1 rounded shadow-md hover:shadow-lg"
+          title="編集"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path
+              d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+            />
+          </svg>
+        </button>
+        <button
+          @click.stop="$emit('click', shoppingRecord.id || 0)"
+          class="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-500 duration-300 bg-red-100 hover:bg-red-200 p-1 rounded shadow-md hover:shadow-lg"
+          title="削除"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
             viewBox="0 0 24 24"
             fill="currentColor"
           >

--- a/src/features/shopping/hooks/__tests__/useKaimemoSummary-edit.test.ts
+++ b/src/features/shopping/hooks/__tests__/useKaimemoSummary-edit.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useKaimemoSummary } from '../useKaimemoSummary'
+import type { components } from '@/shared/api/v1'
+
+// モックセッションストア
+const mockSessionStore = {
+  user: {
+    householdBooks: [
+      {
+        id: 1,
+        title: 'テスト家計簿',
+        categoryLimit: [
+          {
+            id: 1,
+            category: { id: 1, name: '食費', color: '#FF0000' },
+            limitAmount: 30000
+          },
+          {
+            id: 2,
+            category: { id: 2, name: '交通費', color: '#00FF00' },
+            limitAmount: 10000
+          }
+        ]
+      }
+    ]
+  }
+}
+
+// モック
+vi.mock('@/entities/session/model/session-store', () => ({
+  useSessionStore: () => mockSessionStore
+}))
+
+vi.mock('@/features/kaimemo', () => ({
+  useAmountSummaryStore: () => ({
+    mutationShoppingRecords: vi.fn()
+  })
+}))
+
+// API呼び出しのモック
+vi.mock('@/shared/api', () => ({
+  GET: vi.fn().mockResolvedValue({ data: null, error: null }),
+  DELETE: vi.fn().mockResolvedValue({ error: null }),
+  PUT: vi.fn().mockResolvedValue({ error: null })
+}))
+
+// フォームのモック
+vi.mock('vee-validate', () => ({
+  useForm: () => ({
+    defineField: () => [vi.fn(), {}],
+    errors: {},
+    handleSubmit: (fn: unknown) => fn
+  })
+}))
+
+// 分析スキーマのモック
+vi.mock('@/features/analyze', () => ({
+  analyzeSchema: {},
+  type: 'AnalyzeSchema'
+}))
+
+describe('useKaimemoSummary 編集機能', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('初期状態では編集モーダルが閉じている', () => {
+    const {
+      isOpenEditModal,
+      editRecord
+    } = useKaimemoSummary()
+
+    expect(isOpenEditModal.value).toBe(false)
+    expect(editRecord.value).toBeNull()
+  })
+
+  it('onClickEditAmountRecord で編集モーダルが開き、編集対象レコードが設定される', () => {
+    const {
+      onClickEditAmountRecord,
+      isOpenEditModal,
+      editRecord
+    } = useKaimemoSummary()
+
+    const testRecord: components['schemas']['ShoppingRecord'] = {
+      id: 123,
+      amount: 1500,
+      date: '2024-01-15',
+      memo: 'テストメモ',
+      category: { id: 1, name: '食費', color: '#FF0000' },
+      analyze_id: 0
+    }
+
+    onClickEditAmountRecord(testRecord)
+
+    expect(isOpenEditModal.value).toBe(true)
+    expect(editRecord.value).toEqual(testRecord)
+  })
+
+  it('onClickCloseEditAmountModal で編集モーダルが閉じて編集対象レコードがクリアされる', () => {
+    const {
+      onClickEditAmountRecord,
+      onClickCloseEditAmountModal,
+      isOpenEditModal,
+      editRecord
+    } = useKaimemoSummary()
+
+    const testRecord: components['schemas']['ShoppingRecord'] = {
+      id: 123,
+      amount: 1500,
+      date: '2024-01-15',
+      memo: 'テストメモ',
+      category: { id: 1, name: '食費', color: '#FF0000' },
+      analyze_id: 0
+    }
+
+    // 編集モーダルを開く
+    onClickEditAmountRecord(testRecord)
+    expect(isOpenEditModal.value).toBe(true)
+    expect(editRecord.value).toEqual(testRecord)
+
+    // 編集モーダルを閉じる
+    onClickCloseEditAmountModal()
+    expect(isOpenEditModal.value).toBe(false)
+    expect(editRecord.value).toBeNull()
+  })
+
+  it('編集モーダルが開いている間、正しい編集対象レコードが保持される', () => {
+    const {
+      onClickEditAmountRecord,
+      editRecord
+    } = useKaimemoSummary()
+
+    const testRecord1: components['schemas']['ShoppingRecord'] = {
+      id: 123,
+      amount: 1500,
+      date: '2024-01-15',
+      memo: 'テストメモ1',
+      category: { id: 1, name: '食費', color: '#FF0000' },
+      analyze_id: 0
+    }
+
+    const testRecord2: components['schemas']['ShoppingRecord'] = {
+      id: 456,
+      amount: 2000,
+      date: '2024-01-16',
+      memo: 'テストメモ2',
+      category: { id: 2, name: '交通費', color: '#00FF00' },
+      analyze_id: 0
+    }
+
+    // 最初のレコードで編集モーダルを開く
+    onClickEditAmountRecord(testRecord1)
+    expect(editRecord.value).toEqual(testRecord1)
+
+    // 別のレコードで編集モーダルを開く（既存のモーダルが置き換わる）
+    onClickEditAmountRecord(testRecord2)
+    expect(editRecord.value).toEqual(testRecord2)
+  })
+})

--- a/src/features/shopping/hooks/useKaimemoSummary.ts
+++ b/src/features/shopping/hooks/useKaimemoSummary.ts
@@ -11,9 +11,11 @@ export const useKaimemoSummary = () => {
   // TODO : provide, injectで共通的に処理したい
   const loading = ref<boolean>(true)
   const isOpenModal = ref<boolean>(false)
+  const isOpenEditModal = ref<boolean>(false)
   const isOpenDeleteModal = ref<boolean>(false)
   const isOpenReceiptAnalyzeModal = ref<boolean>(false)
   const deleteId = ref<number>(0)
+  const editRecord = ref<components['schemas']['ShoppingRecord'] | null>(null)
   const operatingCurrentDate = ref<Date>(new Date())
   const summarizeShoppingAmounts =
     ref<components['schemas']['SummarizeShoppingAmount']>()
@@ -88,6 +90,18 @@ export const useKaimemoSummary = () => {
 
   const onClickCloseAmountModal = () => {
     isOpenModal.value = false
+
+    fetchShoppingRecords()
+  }
+
+  const onClickEditAmountRecord = (record: components['schemas']['ShoppingRecord']) => {
+    editRecord.value = record
+    isOpenEditModal.value = true
+  }
+
+  const onClickCloseEditAmountModal = () => {
+    isOpenEditModal.value = false
+    editRecord.value = null
 
     fetchShoppingRecords()
   }
@@ -276,8 +290,10 @@ export const useKaimemoSummary = () => {
 
   return {
     isOpenModal,
+    isOpenEditModal,
     isOpenDeleteModal,
     isOpenReceiptAnalyzeModal,
+    editRecord,
     videoRef,
     loading,
     operatingCurrentDate,
@@ -293,6 +309,8 @@ export const useKaimemoSummary = () => {
     tagErrors,
     onClickAddAmountModal,
     onClickCloseAmountModal,
+    onClickEditAmountRecord,
+    onClickCloseEditAmountModal,
     onClickMonthlyPrev,
     onClickMonthlyNext,
     onClickWeeklyPrev,

--- a/src/features/shopping/index.ts
+++ b/src/features/shopping/index.ts
@@ -1,5 +1,6 @@
 export { default as DeleteShoppingAmountModal } from './ui/DeleteShoppingAmountModal.vue'
 export { default as CreateShoppingAmountModal } from './ui/CreateShoppingAmountModal.vue'
+export { default as EditShoppingAmountModal } from './ui/EditShoppingAmountModal.vue'
 export { default as MonthlyHeader } from './ui/MonthlyHeader.vue'
 export { default as HouseHoldTile } from './ui/HouseHoldTile.vue'
 export { useKaimemoSummary } from './hooks/useKaimemoSummary'

--- a/src/features/shopping/ui/EditShoppingAmountModal.vue
+++ b/src/features/shopping/ui/EditShoppingAmountModal.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+  import { BaseModal, PrimaryButton, SecondaryButton } from '@/shared/ui'
+  import { useForm } from 'vee-validate'
+  import { toTypedSchema } from '@vee-validate/zod'
+  import { PUT } from '@/shared/api'
+  import {
+    schema,
+    type KaimemoSummarySchema
+  } from '@/pages/kaimemo-summary/types'
+  import type { components } from '@/shared/api/v1'
+  import { watch } from 'vue'
+
+  const props = defineProps<{
+    isOpen: boolean
+    householdID: number
+    categories: components['schemas']['CategoryLimit'][]
+    shoppingRecord: components['schemas']['ShoppingRecord'] | null
+  }>()
+
+  const emit = defineEmits<{
+    (e: 'close'): void
+  }>()
+
+  const { defineField, errors, handleSubmit, resetForm, setValues } =
+    useForm<KaimemoSummarySchema>({
+      validationSchema: toTypedSchema(schema)
+    })
+
+  const [amount, amountProps] = defineField('amount')
+  const [tag, tagProps] = defineField('tag')
+  const [date, dateProps] = defineField('date')
+  const [memo, memoProps] = defineField('memo')
+
+  // propsが変更されたときにフォームを初期化
+  watch(
+    () => props.shoppingRecord,
+    (newRecord) => {
+      if (newRecord && props.isOpen) {
+        setValues({
+          amount: newRecord.amount,
+          tag: newRecord.category.id,
+          date: newRecord.date,
+          memo: newRecord.memo || ''
+        })
+      }
+    },
+    { immediate: true }
+  )
+
+  const onClickUpdateShoppingRecord = handleSubmit(async values => {
+    if (!props.shoppingRecord) return
+
+    console.log(values)
+
+    const { error } = await PUT('/household/{householdID}/shopping/record/{shoppingID}', {
+      body: {
+        categoryID: values.tag,
+        amount: values.amount,
+        date: values.date,
+        memo: values.memo ?? ''
+      },
+      params: {
+        path: {
+          householdID: props.householdID,
+          shoppingID: props.shoppingRecord.id
+        }
+      }
+    })
+
+    if (error) {
+      console.error(error)
+      return
+    }
+
+    resetForm()
+    emit('close')
+  })
+</script>
+
+<template>
+  <BaseModal
+    title="金額編集"
+    :isOpen="props.isOpen"
+    @closeModal="emit('close')"
+    class="backdrop-blur-md"
+    verticalPosition="top-0"
+    horizontalPosition="left-0"
+  >
+    <template #modalBody>
+      <div class="bg-gradient-to-br from-primary-bg to-white/50 rounded-2xl">
+        <TheForm label="日付">
+          <input
+            type="date"
+            placeholder="支出日を選択してください"
+            class="w-full p-4 border border-primary-light rounded-xl focus:border-primary focus:ring-2 focus:ring-primary-light bg-white/90 text-base"
+            :class="{
+              'border-red-500 bg-red-50/80': errors.date
+            }"
+            v-model="date"
+            v-bind="dateProps"
+          />
+          <p class="mt-2 text-sm text-red-600">
+            {{ errors.date }}
+          </p>
+        </TheForm>
+
+        <TheForm label="カテゴリ">
+          <select
+            class="w-full p-4 border border-primary-light rounded-xl focus:border-primary focus:ring-2 focus:ring-primary-light bg-white/90 text-base"
+            :class="{
+              'border-red-500 bg-red-50/80': errors.tag
+            }"
+            v-model="tag"
+            v-bind="tagProps"
+          >
+            <option value="" disabled>カテゴリを選択してください</option>
+            <template
+              v-for="categoryLimit in categories"
+              :key="categoryLimit.category.id"
+            >
+              <option :value="categoryLimit.category.id">
+                {{ categoryLimit.category.name }}
+              </option>
+            </template>
+          </select>
+          <p class="mt-2 text-sm text-red-600">
+            {{ errors.tag }}
+          </p>
+        </TheForm>
+
+        <TheForm label="金額">
+          <input
+            type="number"
+            placeholder="金額を入力してください（例：1000）"
+            class="w-full p-4 border border-primary-light rounded-xl focus:border-primary focus:ring-2 focus:ring-primary-light bg-white/90 text-base"
+            :class="{
+              'border-red-500 bg-red-50/80': errors.amount
+            }"
+            v-model="amount"
+            v-bind="amountProps"
+          />
+          <p class="mt-2 text-sm text-red-600">
+            {{ errors.amount }}
+          </p>
+        </TheForm>
+
+        <TheForm label="メモ">
+          <textarea
+            placeholder="メモを入力してください（任意）"
+            class="w-full p-4 border border-primary-light rounded-xl focus:border-primary focus:ring-2 focus:ring-primary-light bg-white/90 min-h-[100px] text-base"
+            :class="{
+              'border-red-500 bg-red-50/80': errors.memo
+            }"
+            v-model="memo"
+            v-bind="memoProps"
+          />
+          <p class="mt-2 text-sm text-red-600">
+            {{ errors.memo }}
+          </p>
+        </TheForm>
+      </div>
+    </template>
+
+    <template #buttons>
+      <div class="flex justify-end gap-4">
+        <SecondaryButton
+          @click="emit('close')"
+          class="px-6 py-3 rounded-xl hover:bg-primary-bg transition-all duration-300 transform hover:scale-105"
+        >
+          キャンセル
+        </SecondaryButton>
+        <PrimaryButton
+          @click="onClickUpdateShoppingRecord"
+          class="px-6 py-3 rounded-xl bg-gradient-to-r from-primary to-primary-dark hover:from-primary-dark hover:to-primary transition-all duration-300 transform hover:scale-105 shadow-soft hover:shadow-lg"
+        >
+          更新
+        </PrimaryButton>
+      </div>
+    </template>
+  </BaseModal>
+</template>

--- a/src/pages/kaimemo-summary/ui/KaimemoSummary.vue
+++ b/src/pages/kaimemo-summary/ui/KaimemoSummary.vue
@@ -17,6 +17,7 @@
   import {
     DeleteShoppingAmountModal,
     CreateShoppingAmountModal,
+    EditShoppingAmountModal,
     MonthlyHeader,
     HouseHoldTile,
     useKaimemoSummary
@@ -24,6 +25,7 @@
 
   const {
     isOpenModal,
+    isOpenEditModal,
     operatingCurrentDate,
     categories,
     summarizeShoppingAmounts,
@@ -35,11 +37,14 @@
     sortByAmount,
     isOpenDeleteModal,
     isOpenReceiptAnalyzeModal,
+    editRecord,
     videoRef,
     defineTagField,
     tagErrors,
     onClickAddAmountModal,
     onClickCloseAmountModal,
+    onClickEditAmountRecord,
+    onClickCloseEditAmountModal,
     onClickMonthlyPrev,
     onClickMonthlyNext,
     onClickDeleteAmountRecord,
@@ -111,6 +116,7 @@
           <ShoppingAmountItem
             :shoppingRecord="shoppingRecord"
             @click="onClickOpenDeleteConfirmModal(shoppingRecord.id)"
+            @edit="onClickEditAmountRecord"
           />
         </template>
       </div>
@@ -139,6 +145,14 @@
       :householdID="selectedHouseholdBook.id"
       :categories="categories"
       @close="onClickCloseAmountModal"
+    />
+
+    <EditShoppingAmountModal
+      :isOpen="isOpenEditModal"
+      :householdID="selectedHouseholdBook.id"
+      :categories="categories"
+      :shoppingRecord="editRecord"
+      @close="onClickCloseEditAmountModal"
     />
 
     <DeleteShoppingAmountModal

--- a/src/shared/api/v1.d.ts
+++ b/src/shared/api/v1.d.ts
@@ -150,9 +150,9 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        tempUserID: string;
-                        name: string;
-                        tag: string;
+                        tempUserID?: string;
+                        name?: string;
+                        tag?: string;
                     };
                 };
             };
@@ -201,7 +201,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        tempUserID: string;
+                        tempUserID?: string;
                     };
                 };
             };
@@ -263,13 +263,13 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        tempUserID: string;
+                        tempUserID?: string;
                         /** @example 食費 */
-                        tag: string;
+                        tag?: string;
                         /** @example 2020-01-01 */
-                        date: string;
+                        date?: string;
                         /** @example 1000 */
-                        amount: number;
+                        amount?: number;
                     };
                 };
             };
@@ -318,7 +318,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        tempUserID: string;
+                        tempUserID?: string;
                     };
                 };
             };
@@ -421,8 +421,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        title: string;
-                        description: string;
+                        title?: string;
+                        description?: string;
                     };
                 };
             };
@@ -470,8 +470,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        categoryName: string;
-                        categoryLimitAmount: number;
+                        categoryName?: string;
+                        categoryLimitAmount?: number;
                     };
                 };
             };
@@ -539,11 +539,11 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        householdID: number;
-                        categoryID: number;
-                        amount: number;
-                        date: string;
-                        memo: string;
+                        householdID?: number;
+                        categoryID?: number;
+                        amount?: number;
+                        date?: string;
+                        memo?: string;
                     };
                 };
             };
@@ -574,7 +574,44 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
-        put?: never;
+        /**
+         * 買い物記録更新
+         * @description 買い物記録を更新する
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    householdID: number;
+                    shoppingID: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        categoryID: number;
+                        amount: number;
+                        /** Format: date */
+                        date: string;
+                        memo?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                401: components["responses"]["UnauthorizedError"];
+                404: components["responses"]["NotFoundError"];
+                default: components["responses"]["GeneralError"];
+            };
+        };
         post?: never;
         /**
          * 買い物記録削除
@@ -677,8 +714,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        imageData: string;
-                        categoryID: number;
+                        imageData?: string;
+                        categoryID?: number;
                     };
                 };
             };
@@ -779,7 +816,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        informationIDs: number[];
+                        informationIDs?: number[];
                     };
                 };
             };
@@ -841,10 +878,10 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        title: string;
-                        content: string;
+                        title?: string;
+                        content?: string;
                         /** @enum {string} */
-                        category: "bug_report" | "feature_request" | "other";
+                        category?: "bug_report" | "feature_request" | "other";
                     };
                 };
             };
@@ -890,10 +927,10 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        title: string;
-                        content: string;
+                        title?: string;
+                        content?: string;
                         /** @enum {string} */
-                        category: "bug_report" | "feature_request" | "other";
+                        category?: "bug_report" | "feature_request" | "other";
                     };
                 };
             };
@@ -1028,7 +1065,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        message: string;
+                        message?: string;
                     };
                 };
             };
@@ -1054,133 +1091,133 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         UserAccount: {
-            id: number;
-            name: string;
-            pictureURL: string;
+            id?: number;
+            name?: string;
+            pictureURL?: string;
         };
         FetchMe: {
-            id: number;
-            userID: string;
-            name: string;
-            pictureURL: string;
-            householdBooks: components["schemas"]["HouseholdBook"][];
+            id?: number;
+            userID?: string;
+            name?: string;
+            pictureURL?: string;
+            householdBooks?: components["schemas"]["HouseholdBook"][];
         };
         KaimemoSummary: {
-            monthlySummaries: components["schemas"]["MonthlySummary"][];
-            weeklySummaries: components["schemas"]["WeeklySummary"][];
+            monthlySummaries?: components["schemas"]["MonthlySummary"][];
+            weeklySummaries?: components["schemas"]["WeeklySummary"][];
         };
         TagSummary: {
             [key: string]: number;
         };
         MonthlySummary: {
-            month: string;
+            month?: string;
             /** @example 10000 */
-            totalAmount: number;
-            tagSummary: components["schemas"]["TagSummary"];
+            totalAmount?: number;
+            tagSummary?: components["schemas"]["TagSummary"];
         };
         WeeklySummary: {
-            weekStart: string;
-            weekEnd: string;
-            totalAmount: number;
-            items: components["schemas"]["KaimemoAmount"][];
+            weekStart?: string;
+            weekEnd?: string;
+            totalAmount?: number;
+            items?: components["schemas"]["KaimemoAmount"][];
         };
         KaimemoAmount: {
-            id: string;
+            id?: string;
             /** @example 2020-01-01 */
-            date: string;
+            date?: string;
             /** @example 食費 */
-            tag: string;
+            tag?: string;
             /** @example 1000 */
-            amount: number;
+            amount?: number;
         };
         Kaimemo: {
-            id: string;
-            name: string;
-            tag: string;
-            done: boolean;
+            id?: string;
+            name?: string;
+            tag?: string;
+            done?: boolean;
         };
         HouseholdBook: {
-            id: number;
-            userID: number;
-            title: string;
-            description: string;
-            categoryLimit: components["schemas"]["CategoryLimit"][];
-            users: components["schemas"]["UserAccount"][];
+            id?: number;
+            userID?: number;
+            title?: string;
+            description?: string;
+            categoryLimit?: components["schemas"]["CategoryLimit"][];
+            users?: components["schemas"]["UserAccount"][];
         };
         CategoryLimit: {
-            id: number;
-            categoryID: number;
-            limitAmount: number;
-            category: components["schemas"]["Category"];
+            id?: number;
+            categoryID?: number;
+            limitAmount?: number;
+            category?: components["schemas"]["Category"];
         };
         Category: {
-            id: number;
-            name: string;
-            color: string;
+            id?: number;
+            name?: string;
+            color?: string;
         };
         ShoppingMemo: {
-            id: number;
-            householdID: number;
-            categoryID: number;
-            title: string;
-            memo: string;
-            isCompleted: boolean;
-            category: components["schemas"]["Category"];
+            id?: number;
+            householdID?: number;
+            categoryID?: number;
+            title?: string;
+            memo?: string;
+            isCompleted?: boolean;
+            category?: components["schemas"]["Category"];
         };
         ShoppingRecord: {
-            id: number;
-            amount: number;
-            date: string;
-            memo: string;
-            category: components["schemas"]["Category"];
-            analyze_id: number;
-            receipt_analyze_results: components["schemas"]["ReceiptAnalyzeResult"];
+            id?: number;
+            amount?: number;
+            date?: string;
+            memo?: string;
+            category?: components["schemas"]["Category"];
+            analyze_id?: number;
+            receipt_analyze_results?: components["schemas"]["ReceiptAnalyzeResult"];
         };
         CategoryAmount: {
-            category: components["schemas"]["Category"];
-            amount: number;
-            limitAmount: number;
+            category?: components["schemas"]["Category"];
+            amount?: number;
+            limitAmount?: number;
         };
         SummarizeShoppingAmount: {
-            shoppingAmounts: components["schemas"]["ShoppingRecord"][];
-            totalAmount: number;
-            categoryAmounts: components["schemas"]["CategoryAmount"][];
+            shoppingAmounts?: components["schemas"]["ShoppingRecord"][];
+            totalAmount?: number;
+            categoryAmounts?: components["schemas"]["CategoryAmount"][];
         };
         ReceiptAnalyzeResultItem: {
-            id: number;
-            name: string;
-            amount: number;
+            id?: number;
+            name?: string;
+            amount?: number;
         };
         ReceiptAnalyzeResult: {
-            id: number;
-            totalAmount: number;
-            receiptImageURL: string;
-            items: components["schemas"]["ReceiptAnalyzeResultItem"][];
+            id?: number;
+            totalAmount?: number;
+            receiptImageURL?: string;
+            items?: components["schemas"]["ReceiptAnalyzeResultItem"][];
         };
         Information: {
-            id: number;
-            title: string;
-            content: string;
-            isPublished: boolean;
+            id?: number;
+            title?: string;
+            content?: string;
+            isPublished?: boolean;
             /** @enum {string} */
-            category: "bug_report" | "feature_request" | "other";
+            category?: "bug_report" | "feature_request" | "other";
         };
         UserInformation: {
-            id: number;
-            title: string;
-            content: string;
-            isRead: boolean;
+            id?: number;
+            title?: string;
+            content?: string;
+            isRead?: boolean;
             /** @enum {string} */
-            category: "bug_report" | "feature_request" | "other";
+            category?: "bug_report" | "feature_request" | "other";
         };
         ChatMessage: {
-            id: number;
-            userID: number;
-            userName: string;
-            content: string;
+            id?: number;
+            userID?: number;
+            userName?: string;
+            content?: string;
             /** @enum {string} */
-            messageType: "user" | "ai";
-            createdAt: string;
+            messageType?: "user" | "ai";
+            createdAt?: string;
         };
     };
     responses: {


### PR DESCRIPTION
## Summary
- 買い物記録の編集機能を実装
- 編集ボタンの追加とモーダル形式での編集UI
- API連携による記録更新機能

## Test plan
- [ ] 編集ボタンがShoppingAmountItemに表示される
- [ ] 編集ボタンクリックで編集モーダルが開く
- [ ] 編集モーダルに既存の記録データが表示される
- [ ] 編集内容を保存して記録が更新される
- [ ] 編集モーダルがキャンセルできる
- [ ] 編集機能のユニットテストが通る

🤖 Generated with [Claude Code](https://claude.ai/code)