### PR TITLE
feat: mainブランチマージ時に自動デプロイ機能を追加

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,6 +2,8 @@ name: dev-deploy-frontend
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'dev-*'
 


### PR DESCRIPTION
## Summary
- mainブランチにマージされた際に自動的にデプロイが実行されるように設定
- 既存のdev-*タグでのデプロイ機能は保持

## Changes
- `.github/workflows/dev-deploy.yml` を修正
- `on.push` に `branches: [main]` を追加
- 既存の `tags: ['dev-*']` トリガーは維持

## 修正内容
```yaml
on:
  push:
    branches:
      - main
    tags:
      - 'dev-*'
```

## 動作
- **mainブランチへのマージ/プッシュ**: 自動デプロイ実行
- **dev-*タグのプッシュ**: 従来通りデプロイ実行

## Test plan
- [ ] YAMLファイルの構文が正しい
- [ ] ビルドが正常に動作する
- [ ] GitHub Actionsがトリガーされることを確認
- [ ] 既存のタグベースデプロイが影響を受けない

## 利点
- マージ時の手動タグ作成が不要
- より迅速なデプロイサイクル
- 開発効率の向上

🤖 Generated with [Claude Code](https://claude.ai/code)